### PR TITLE
Add command line options for library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Usage: migrate.py [OPTIONS]
 Options:
   --plex-url TEXT        Plex server url  [required]
   --plex-token TEXT      Plex token  [required]
+  --plex-movie-lib TEXT  Name of plex movie library
+  --plex-tv-lib TEXT     Name of plex tv library
   --jellyfin-url TEXT    Jellyfin server url
   --jellyfin-token TEXT  Jellyfin token
   --jellyfin-user TEXT   Jellyfin user

--- a/migrate.py
+++ b/migrate.py
@@ -30,9 +30,12 @@ class bcolors:
 @click.option('--secure/--insecure', help='Verify SSL')
 @click.option('--debug/--no-debug', help='Print more output')
 @click.option('--no-skip/--skip', help='Skip when no match it found instead of exiting')
+@click.option('--plex-tv-lib', default='TV Shows', help='Name of Plex TV library')
+@click.option('--plex-movie-lib', default='Films', help='Name of Plex movie library')
 def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
             jellyfin_token: str, jellyfin_user: str,
-            secure: bool, debug: bool, no_skip: bool):
+            secure: bool, debug: bool, no_skip: bool,
+            plex_tv_lib: str, plex_movie_lib: str):
 
     # Remove insecure request warnings
     if not secure:
@@ -51,7 +54,7 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
 
     # Get all Plex watched movies
     # TODO: remove harcoded library name
-    plex_movies = plex.library.section('Films')
+    plex_movies = plex.library.section(plex_movie_lib)
     for m in plex_movies.search(unwatched=False):
         info = _extract_provider(data=m.guid)
 
@@ -66,10 +69,10 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
         plex_watched.append(info)
 
     # Get all Plex watched episodes
-    plex_tvshows = plex.library.section('TV Shows')
+    plex_tvshows = plex.library.section(plex_tv_lib)
     plex_watched_episodes = []
     for show in plex_tvshows.search(**{"episode.unwatched": False}):
-        for e in plex.library.section('TV Shows').get(show.title).episodes():
+        for e in plex.library.section(plex_tv_lib).get(show.title).episodes():
             info = _extract_provider(data=e.guid)
             
             # TODO: feels copy paste of above, move to function


### PR DESCRIPTION
You can now specify the names of your libraries via command line options `--plex-movie-lib` and `--plex-tv-lib`. If these are not provided, they default to the previously hardcoded names.

Fixes #9 #15 