### PR TITLE
Added support for multiple agents, but removed support for series

### DIFF
--- a/jellyfin_client.py
+++ b/jellyfin_client.py
@@ -55,13 +55,24 @@ class JellyFinServer:
         Returns:
             List: List of results
         """
-        q = {
-            'Recursive': True,
-            'Fields': 'ProviderIds'
-        }
-        result = self._get(
-            endpoint=f"Users/{user_id}/Items", payload=q)
-        return result['Items']
+        results = []
+        startIndex = 0
+        while True:
+            q = {
+                'Recursive': True,
+                'Fields': 'ProviderIds',
+                'startIndex': startIndex,
+                'Limit': 10,
+                'includeItemTypes': 'Movie',
+            }
+            n = self._get(
+                endpoint=f"Users/{user_id}/Items", payload=q)['Items']
+            results += n
+            startIndex += 10
+            print(f"Fetched {startIndex} movies from jellyfin {[r['Name'] for r in results[-10:]]}")
+            if len(n) == 0:
+                break
+        return results
 
     def search_by_provider(self, user_id: str, provider: str, item_id: str) -> List:
         """Search items by provider id

--- a/jellyfin_client.py
+++ b/jellyfin_client.py
@@ -11,15 +11,16 @@ class JellyFinServer:
     session: requests.Session
 
     def _get(self, endpoint: str, payload: Optional[dict] = {}) -> dict:
+        url = '{}/{}'.format(self.url, endpoint)
         payload['api_key'] = self.api_key
         r = self.session.get(
-            url='{}/{}'.format(self.url, endpoint), params=payload)
+            url=url, params=payload, timeout=60)
         return r.json()
 
     def _post(self, endpoint, payload: Optional[dict] = {}) -> bool:
         payload['api_key'] = self.api_key
         r = self.session.post(
-            url='{}/{}'.format(self.url, endpoint), params=payload)
+            url='{}/{}'.format(self.url, endpoint), params=payload, timeout=60)
 
     def get_users(self) -> List[dict]:
         """Get all Jellfin user

--- a/jellyfin_client.py
+++ b/jellyfin_client.py
@@ -58,19 +58,20 @@ class JellyFinServer:
         """
         results = []
         startIndex = 0
+        batchSize = 100
         while True:
             q = {
                 'Recursive': True,
                 'Fields': 'ProviderIds',
                 'startIndex': startIndex,
-                'Limit': 10,
+                'Limit': batchSize,
                 'includeItemTypes': 'Movie',
             }
             n = self._get(
                 endpoint=f"Users/{user_id}/Items", payload=q)['Items']
             results += n
-            startIndex += 10
-            print(f"Fetched {startIndex} movies from jellyfin {[r['Name'] for r in results[-10:]]}")
+            startIndex += batchSize
+            print(f"Fetched {startIndex} items from jellyfin {[str(r) for r in results[-3:]]}")
             if len(n) == 0:
                 break
         return results

--- a/migrate.py
+++ b/migrate.py
@@ -23,6 +23,17 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+agents_movies = [
+    {"plex": "themoviedb", "jellyfin": "Tmdb"},
+    {"plex": "imdb", "jellyfin": "Imdb"},
+]
+
+def _jellyfin_agent_from_plex(plex_agent_name: str) -> Optional[str]:
+    for a in agents_movies:
+        if a['plex'] == plex_agent_name:
+            return a['jellyfin']
+    return None
+
 
 @click.command()
 @click.option('--plex-url', required=True, help='Plex server url')
@@ -32,13 +43,12 @@ class bcolors:
 @click.option('--jellyfin-user', help='Jellyfin user')
 @click.option('--secure/--insecure', help='Verify SSL')
 @click.option('--debug/--no-debug', help='Print more output')
-@click.option('--no-skip/--skip', help='Skip when no match it found instead of exiting')
-@click.option('--plex-tv-lib', default='TV Shows', help='Name of Plex TV library')
-@click.option('--plex-movie-lib', default='Films', help='Name of Plex movie library')
+@click.option('--dry-run/--no-dry-run', help='Verify SSL', default=False)
+@click.option('--plex-movie-lib', required=True, help='Name of Plex movie library')
 def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
             jellyfin_token: str, jellyfin_user: str,
-            secure: bool, debug: bool, no_skip: bool,
-            plex_tv_lib: str, plex_movie_lib: str):
+            secure: bool, debug: bool, dry_run: bool,
+            plex_movie_lib: str):
 
     # Remove insecure request warnings
     if not secure:
@@ -55,58 +65,67 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
     # Watched list from Plex
     plex_watched = []
 
-    # Get all Plex watched movies
-    # TODO: remove harcoded library name
-    plex_movies = plex.library.section(plex_movie_lib)
-    for m in plex_movies.search(unwatched=False):
-        info = _extract_provider(data=m.guid)
+    try:
+        with open('cache_plex.pkl', 'rb') as f:
+            plex_watched = pickle.load(f)
+    except Exception:
+        # Get all Plex watched movies
+        if plex_movie_lib is not None:
+            plex_movies = plex.library.section(plex_movie_lib)
+            for m in plex_movies.search(unwatched=False):
+                infos = []
+                for agent in agents_movies:
+                    # Take only the first result of each agent
+                    agent_matches = m.matches(agent=agent['plex'])
+                    if len(agent_matches) == 0:
+                        continue
+                    best_agent_match = agent_matches[0]
+                    info = _extract_provider(guid=best_agent_match.guid)
+                    info['agent_title'] = best_agent_match.name
+                    info['original_title'] = m.title
+                    infos.append(info)
 
-        if not info:
-            print(f"{bcolors.WARNING}No provider match in {m.guid} for {m.title}{bcolors.ENDC}")
-            if no_skip:
-                sys.exit(1)
-            else:
-                continue
-
-        info['title'] = m.title
-        plex_watched.append(info)
-
-    # Get all Plex watched episodes
-    plex_tvshows = plex.library.section(plex_tv_lib)
-    plex_watched_episodes = []
-    for show in plex_tvshows.search(**{"episode.unwatched": False}):
-        for e in plex.library.section(plex_tv_lib).get(show.title).episodes():
-            info = _extract_provider(data=e.guid)
-            
-            # TODO: feels copy paste of above, move to function
-            if not info:
-                print(f"{bcolors.WARNING}No provider match in {e.guid} for {show.title} {e.seasonEpisode.capitalize()} {bcolors.ENDC}")
-                if no_skip:
-                    sys.exit(1)
-                else:
+                if len(infos) == 0:
+                    print(f"{bcolors.WARNING}No match for plex item {m.title}{bcolors.ENDC}")
                     continue
+                else:
+                    infos_str = infos[0]['original_title'] + " ->"
+                    for info in infos:
+                        infos_str += f" {info['provider']}:{info['item_id']} {info['agent_title']}"
+                    print(f"{bcolors.OKGREEN}Matches for {m.title}: {infos_str}{bcolors.ENDC}")
 
-            info['title'] = f"{show.title} {e.seasonEpisode.capitalize()} {e.title}"  # s01e03 > S01E03
-            plex_watched.append(info)
+                plex_watched.append(infos)
+
+        with open('cache_plex.pkl', 'wb') as f:
+            pickle.dump(plex_watched, f)
+
+        
 
     # This gets all jellyfin movies since filtering on provider id isn't supported:
     # https://github.com/jellyfin/jellyfin/issues/1990
     jf_uid = jellyfin.get_user_id(name=jellyfin_user)
-    jf_library = jellyfin.get_all(user_id=jf_uid)
+
+    try:
+        with open('cache_jellyfin.pkl', 'rb') as f:
+            jf_library = pickle.load(f)
+    except Exception:
+        jf_library = jellyfin.get_all(user_id=jf_uid)
+        with open('cache_jellyfin.pkl', 'wb') as f:
+            pickle.dump(jf_library, f)
 
     for watched in plex_watched:
+        # print(f"Searching for {watched[0]['original_title']} in {len(jf_library)} items.")
         search_result = _search(jf_library, watched)
         if search_result and not search_result['UserData']['Played']:
-            jellyfin.mark_watched(
-                user_id=jf_uid, item_id=search_result['Id'])
-            print(f"{bcolors.OKGREEN}Marked {watched['title']} as watched{bcolors.ENDC}")
+            if not dry_run:
+                jellyfin.mark_watched(
+                    user_id=jf_uid, item_id=search_result['Id'])
+            print(f"{bcolors.OKGREEN}Marked {watched[0]['original_title']} as watched{bcolors.ENDC}")
         elif not search_result:
-            print(f"{bcolors.WARNING}No matches for {watched['title']}{bcolors.ENDC}")
-            if no_skip:
-                sys.exit(1)
+            print(f"{bcolors.WARNING}No matches for {watched[0]['original_title']}{bcolors.ENDC}")
         else:
             if debug:
-                print(f"{bcolors.OKBLUE}{watched['title']}{bcolors.ENDC}")
+                print(f"{bcolors.OKBLUE}{watched[0]['original_title']} already marked as watched{bcolors.ENDC}")
 
     print(f"{bcolors.OKGREEN}Succesfully migrated {len(plex_watched)} items{bcolors.ENDC}")
 
@@ -122,28 +141,29 @@ def _search(lib_data: dict, item: dict) -> List:
         List: [description]
     """
     for data in lib_data:
-        if data['ProviderIds'].get(item['provider']) == item['item_id']:
-            return data
+        for provider in item:
+            if data['ProviderIds'].get(_jellyfin_agent_from_plex(provider['provider'])) == provider['item_id']:
+                return data
+    return None
 
 
-def _extract_provider(data: dict) -> dict:
+def _extract_provider(guid: str) -> dict:
     """Extract Plex provider and return JellyFin compatible data
 
     Args:
-        data (dict): plex episode or movie guid
+        data (dict): movie guid
 
     Returns:
-        dict: provider in JellyFin format and item_id as identifier
+        dict: provider in plex format and item_id as identifier
     """
     result = {}
 
     # example: 'com.plexapp.agents.imdb://tt1068680?lang=en'
-    # example: 'com.plexapp.agents.thetvdb://248741/1/1?lang=en'
-    match = re.match('com\.plexapp\.agents\.(.*):\/\/(.*)\?', data)
+    match = re.match('com\.plexapp\.agents\.(.*):\/\/(.*)\?', guid)
 
     if match:
         result = {
-            'provider': match.group(1).replace('the', '').capitalize(),  # Jellyfin uses Imdb and Tvdb
+            'provider': match.group(1),
             'item_id': match.group(2)
         }
 

--- a/migrate.py
+++ b/migrate.py
@@ -1,10 +1,13 @@
-from typing import List
+#!/bin/python3
+
+from typing import List, Optional
 
 import requests
 import urllib3
 import click
 import re
 import sys
+import pickle
 
 from plexapi.server import PlexServer
 from jellyfin_client import JellyFinServer
@@ -149,3 +152,4 @@ def _extract_provider(data: dict) -> dict:
 
 if __name__ == '__main__':
     migrate()
+


### PR DESCRIPTION
I believe the default now is for plex collections to use the plex agent.
Therefore there is no straightforward way to look for matches in imdb or another shared database.

This PR solves this issue thanks to the `matches()` method:

```python3
plex_movies = plex.library.section(plex_movie_lib)
for m in plex_movies.search(unwatched=False):
    for agent in agents_movies:
        agent_matches = m.matches(agent=agent['plex'])
```

This also adds support for multiple agents, for instance themoviedb could be used to match some movies and imdb for others. As far as I know this works even if these libraries are not enabled in the plex server, since this function call triggers match attempt.

On the other hand, I could not find a suitable solution for series, since individual episodes don't have the `matches` method. Therefore I remove support for series entirely for now.

Various other improvements include:
 - A dry run option
 - A pickle cache for the jellyfin and plex libraries
 - Improved messages

The code is still not very polished so I understand if you prefer not to pull it, but I hope others can benefit from my tweaks.