### PR TITLE
Total rework of the match logic: Use pathnames instead of providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Migrate Plex to Jellyfin
 
-WIP, project to migrate Plex watched statusses to Jellyfin :)
+WIP, project to migrate Plex watched statusses to Jellyfin, based on the file name of the media :)
 
 ## Getting started
 
@@ -25,8 +25,6 @@ Usage: migrate.py [OPTIONS]
 Options:
   --plex-url TEXT        Plex server url  [required]
   --plex-token TEXT      Plex token  [required]
-  --plex-movie-lib TEXT  Name of plex movie library
-  --plex-tv-lib TEXT     Name of plex tv library
   --jellyfin-url TEXT    Jellyfin server url
   --jellyfin-token TEXT  Jellyfin token
   --jellyfin-user TEXT   Jellyfin user

--- a/jellyfin_client.py
+++ b/jellyfin_client.py
@@ -57,7 +57,7 @@ class JellyFinServer:
         """
         q = {
             'Recursive': True,
-            'Fields': 'ProviderIds'
+            'Fields': 'MediaSources'
         }
         result = self._get(
             endpoint=f"Users/{user_id}/Items", payload=q)

--- a/migrate.py
+++ b/migrate.py
@@ -81,9 +81,12 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
 
 
     marked = 0
+    missing = 0
+    skipped = 0
     for watched in plex_watched:
         if watched not in jf_entries:
             logger.bind(path=watched).warning("no match found on jellyfin")
+            missing += 1
             continue
         for jf_entry in jf_entries[watched]:
             if not jf_entry["UserData"]["Played"]:
@@ -91,10 +94,10 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
                 jellyfin.mark_watched(user_id=jf_uid, item_id=jf_entry["Id"])
                 logger.bind(path=watched, jf_id=jf_entry["Id"], title=jf_entry["Name"]).info("Marked as watched")
             else:
+                skipped += 1
                 logger.bind(path=watched, jf_id=jf_entry["Id"], title=jf_entry["Name"]).debug("Skipped marking already-watched media")
 
-
-    logger.success(f"Succesfully migrated {marked} items")
+    logger.bind(updated=marked, missing=missing, skipped=skipped).success(f"Succesfully migrated watched states to jellyfin")
 
 
 def _watch_parts(media: List[Media]) -> Set[str]:

--- a/migrate.py
+++ b/migrate.py
@@ -66,15 +66,15 @@ def migrate(plex_url: str, plex_token: str, jellyfin_url: str,
     # Get all Plex watched movies
     for section in plex.library.sections():
         if isinstance(section, library.MovieSection):
-            plex_movies = plex.library.section(section.title)
+            plex_movies = section
             for m in plex_movies.search(unwatched=False):
                 parts=_watch_parts(m.media)
                 plex_watched.update(parts)
                 logger.bind(section=section.title, movie=m, parts=parts).debug("watched movie")
         elif isinstance(section, library.ShowSection):
-            plex_tvshows = plex.library.section(section.title)
-            for show in plex_tvshows.search(**{"episode.unwatched": False}):
-                for e in plex.library.section(section.title).get(show.title).episodes():
+            plex_tvshows = section
+            for show in plex_tvshows.searchShows(**{"episode.unwatched": False}):
+                for e in show.watched():
                     parts=_watch_parts(e.media)
                     plex_watched.update(parts)
                     logger.bind(section=section.title, ep=e, parts=parts).debug("watched episode")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 plexapi
 click
 requests
+loguru


### PR DESCRIPTION
The current version of this migration tool will look at every media item in two libraries ("the" TV and "the" Movies plex library), extracts the "provider IDs" and then tries to match it to any media entry on the jellyfin side. That works until the providers get out of sync (e.g. as of a few years ago, when Plex started making their own metadata provider).

So instead, this PR tries to cover a wholly different method that should work for most (but certainly not all!) use cases for migration: It extracts the filenames underlying each media entry, then matches those file names on the jellyfin side. If you're migrating from plex to jellyfin on the same machine and the paths stay the same, this is likely going to match just about everything in both libraries.

This approach also has the advantage that it no longer requires specifying "the one" movie and TV library section on the plex side: Instead, it asks Plex for each library section and just goes through them all.

The PR also adjusts the logging to use `loguru`, which results in far more detailed and legible log messages.