### PR TITLE
Added Windows-Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
   --jellyfin-url TEXT       Jellyfin server url  [required]
   --jellyfin-token TEXT     Jellyfin token  [required]
   --jellyfin-user TEXT      Jellyfin user  [required]
-  --translate PATH:PATH  Translate plex paths to jellyfin
+  --translate PATH|PATH  Translate plex paths to jellyfin
   --secure / --insecure     Verify SSL
   --debug / --no-debug      Print more output
   --no-skip / --skip        Skip when no match it found instead of exiting

--- a/migrate.py
+++ b/migrate.py
@@ -32,7 +32,8 @@ def build_translation_library(args: List[str]) -> TranslationLib:
     tranlations: TranslationLib = []
 
     for arg in args:
-        src, dst = arg.split(":", 1)
+        src, dst = arg.split("|", 1)
+
         tranlations.append(PathTranslation(src=src, dst=dst))
 
     return tranlations
@@ -44,6 +45,13 @@ def translate_path(path: str, translations: TranslationLib) -> str:
     for t in translations:
         if tr_path.startswith(t.src):
             tr_path = t.dst + tr_path[len(t.src) :]
+
+            # If dst is Linux-ish, normalise to forward slashes
+            if "/" in t.dst and "\\" in tr_path:
+                tr_path = tr_path.replace("\\", "/")
+            # If dst is Windows-ish, normalise to backslashes
+            elif "\\" in t.dst and "/" in tr_path:
+                tr_path = tr_path.replace("/", "\\")
 
     return tr_path
 

--- a/test_translate.py
+++ b/test_translate.py
@@ -4,10 +4,11 @@ from migrate import PathTranslation, build_translation_library, translate_path
 
 EXAMPLE_FILENAME = "Meet the Press (1947)/Season 2020/S2020E01 - January 5, 2020 [SDTV x264 AAC].mp4"
 
+
 def test_build_library() -> None:
     assert build_translation_library(
         [
-            "/media:/mnt/media",
+            "/media|/mnt/media",
         ]
     ) == [
         PathTranslation("/media", "/mnt/media"),
@@ -16,13 +17,11 @@ def test_build_library() -> None:
 
 def test_translate_path_empty() -> None:
     """Test translate_path with an empty translation set."""
-
     assert translate_path("foo", []) == "foo"
 
 
 def test_translate_path_simple() -> None:
-    """Test translate_path with an empty translation set."""
-
+    """Test translate_path with a simple single translation."""
     assert (
         translate_path(
             f"/media/television/{EXAMPLE_FILENAME}",
@@ -35,8 +34,7 @@ def test_translate_path_simple() -> None:
 
 
 def test_translate_path_one_of_many() -> None:
-    """Test translate_path with an empty translation set."""
-
+    """Test translate_path uses the first matching translation."""
     assert (
         translate_path(
             f"/media/television/{EXAMPLE_FILENAME}",
@@ -50,8 +48,7 @@ def test_translate_path_one_of_many() -> None:
 
 
 def test_translate_path_multiple() -> None:
-    """Test translate_path with an empty translation set."""
-
+    """Test translate_path applying chained translations across multiple calls."""
     assert (
         translate_path(
             f"/media/television/{EXAMPLE_FILENAME}",
@@ -62,3 +59,42 @@ def test_translate_path_multiple() -> None:
         )
         == f"/tv/{EXAMPLE_FILENAME}"
     )
+
+
+def test_translate_path_windows_to_linux_normalizes_separators() -> None:
+    """Windows-style Plex path should translate to Linux-style and normalize slashes."""
+    plex_path = rf"D:\Media\television\{EXAMPLE_FILENAME}"
+    assert (
+        translate_path(
+            plex_path,
+            [
+                PathTranslation(r"D:\Media", "/mnt/media"),
+            ],
+        )
+        == f"/mnt/media/television/{EXAMPLE_FILENAME}"
+    )
+
+
+def test_translate_path_linux_to_windows_normalizes_separators() -> None:
+    """Linux-style path should translate to Windows-style and normalize slashes."""
+    linux_path = f"/mnt/media/television/{EXAMPLE_FILENAME}"
+    assert (
+        translate_path(
+            linux_path,
+            [
+                PathTranslation("/mnt/media", r"D:\Media"),
+            ],
+        )
+        == rf"D:\Media\television\{EXAMPLE_FILENAME}"
+    )
+
+
+def test_translate_path_build_library_windows_mapping() -> None:
+    """Ensure build_translation_library handles Windows src/dst with the '|' delimiter."""
+    assert build_translation_library(
+        [
+            r"D:\Media|/mnt/media",
+        ]
+    ) == [
+        PathTranslation(r"D:\Media", "/mnt/media"),
+    ]


### PR DESCRIPTION
I encountered some issues migrating my Windows Plex to my Linux JellyFin due to the implementation of the translate property. It uses a colon as a separator but windows paths use this for their drive letter (i.e. D:/Videos...). In addition, Windows uses backslashes as separators instead of forward slashes. I had to make some changes to get it to run and thought they may be beneficial to others

Changes
- Changed the delimiter in `build_translation_library` from `:` to `|`. This is a breaking change, but I assume most people will be using the latest version as a one-off
- Added steps to `translate_path` to normalise the forward/backslashes
- Updated translation tests