### PR TITLE
Feat: Periodic migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,12 @@ docker build -t migrate-plex-to-jellyfin:local .
 
 then run it using the following command:
 ```
-docker run migrate-plex-to-jellyfin:local --insecure --debug --plex-url https://plex.test.com:32400 --plex-token 123123123 --jellyfin-url https://jellyfin.test.com --jellyfin-token 123123123 --jellyfin-user user
+docker run --rm \
+  -e CRON_SCHEDULE="*/15 * * * *" \
+  -e PLEX_URL="https://plex.test.com:32400" \
+  -e PLEX_TOKEN="123123123" \
+  -e JELLYFIN_URL="https://jellyfin.test.com" \
+  -e JELLYFIN_TOKEN="123123123" \
+  -e JELLYFIN_USER="user" \
+  migrate-plex-to-jellyfin:local
 ```

--- a/create_cron.sh
+++ b/create_cron.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+SCHEDULE="${CRON_SCHEDULE:-0/15 * * * *}"
+PLEX_URL="${PLEX_URL?Error: PLEX_URL is required}"
+PLEX_TOKEN="${PLEX_TOKEN?Error: PLEX_TOKEN is required}"
+JELLYFIN_URL="${JELLYFIN_URL?Error: JELLYFIN_URL is required}"
+JELLYFIN_TOKEN="${JELLYFIN_TOKEN?Error: JELLYFIN_TOKEN is required}"
+JELLYFIN_USER="${JELLYFIN_USER?Error: JELLYFIN_USER is required}"
+ADDITIONAL_ARGS="${ADDITIONAL_ARGS:-}"
+
+SCRIPT_PATH="/usr/src/app/migrate.py"
+CMD="python3 $SCRIPT_PATH $ADDITIONAL_ARGS --plex-url $PLEX_URL --plex-token $PLEX_TOKEN --jellyfin-url $JELLYFIN_URL --jellyfin-token $JELLYFIN_TOKEN --jellyfin-user $JELLYFIN_USER"
+
+(crontab -l 2>/dev/null; echo "$SCHEDULE $CMD") | crontab -
+
+echo "Cron job added successfully:"
+crontab -l | grep migrate.py
+
+eval "$CMD"
+
+echo "Starting cron daemon..."
+exec crond -f -l 2

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,6 @@
-# BUILD STAGE
-FROM python:slim
+FROM python:3.12-alpine
+
+RUN apk add --no-cache bash tini
 
 WORKDIR /usr/src/app
 
@@ -8,6 +9,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT [ "python3", "migrate.py" ]
+RUN chmod +x create_cron.sh
 
-CMD [ "python3", "migrate.py", "--help" ]
+ENTRYPOINT ["/sbin/tini", "--", "./create_cron.sh"]


### PR DESCRIPTION
This adds a periodicity to the included docker container.

It's particularly useful for people who are moving slowly or just checking Jellyfin out.

It kind of retains the previous functionality by running the script once the container boots, however users can still exec into the container and perform ad-hoc migration as well.
(Totally understand if you want to retain the functionality 1:1, but given all computers come with venv preinstalled, I wouldn't sweat it 🙂)